### PR TITLE
Correcting az command query

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ az login
 
 ## Assign RBAC permissions to the storage account
 
-Azure storage accounts require explicit permissions to perform read and write operations. In order to use the storage account, you must assign permissions to the account. To do that you'll need to assing an appropriate RBAC role to your account. To get the `objectID` of the currently signed in user, run `az ad signed-in-user show --query objectId`.
+Azure storage accounts require explicit permissions to perform read and write operations. In order to use the storage account, you must assign permissions to the account. To do that you'll need to assing an appropriate RBAC role to your account. To get the `objectID` of the currently signed in user, run `az ad signed-in-user show --query id`.
 
 Run the following AzureCli command to assign the storage account permissions:
 


### PR DESCRIPTION
az ad signed-in-user show --query objectId returns nothing, command should query "id" instead to get signed in user id which is the object id.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Correct readme instructions

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x] Documentation content changes
[ ] Other... Please describe:
```
